### PR TITLE
Remove `base-bytes` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,6 @@
  (description "These bindings use [ctypes](https://github.com/ocamllabs/ocaml-ctypes)
 for type-safe stub generation.")
  (depends
-  base-bytes
   (cf (>= "0.4"))
   (ctypes (>= "0.4.0"))))
 

--- a/fsevents.opam
+++ b/fsevents.opam
@@ -11,7 +11,6 @@ homepage: "https://github.com/mirage/ocaml-fsevents"
 bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
 depends: [
   "dune" {>= "2.8"}
-  "base-bytes"
   "cf" {>= "0.4"}
   "ctypes" {>= "0.4.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
It is implied in 4.02 anyway and that's the lowest OCaml version dune supports.